### PR TITLE
Fix value realized select all bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -2240,7 +2240,15 @@
     };
     
     window.toggleSelectAll = function(section) {
-      const checkbox = $(`#${section.toLowerCase()}-select-all`);
+      // Map section names to their HTML element IDs
+      const sectionIdMap = {
+        'objectives': 'objectives',
+        'valueRealized': 'value-realized',
+        'pastObjectives': 'past-objectives'
+      };
+      const sectionId = sectionIdMap[section] || section.toLowerCase();
+      
+      const checkbox = $(`#${sectionId}-select-all`);
       const items = section === 'objectives' ? state.objectives :
                    section === 'valueRealized' ? state.valueRealized :
                    state.pastObjectives;


### PR DESCRIPTION
Fix 'select all' functionality for the Value Realized section.

The `toggleSelectAll` function was attempting to find the "select all" checkbox using `#valuerealized-select-all` (lowercase, no hyphen), but the actual ID in the HTML was `#value-realized-select-all` (with hyphen). This PR introduces a mapping to correctly resolve the section name to its corresponding HTML ID.

---
<a href="https://cursor.com/background-agent?bcId=bc-a502ecb9-e113-4420-9a2e-849b22f39f5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a502ecb9-e113-4420-9a2e-849b22f39f5d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

